### PR TITLE
Add What the Taiji?! to supported list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ printTable(pdShared.getGames())
 
 ##### Supported games
 * Pomo Post - `com.gammagames.pomodoro`
+* What the Taiji?! - `net.marquiskurt.what-the-taiji`
 
 ### `pdShared.shareData([data])`
 


### PR DESCRIPTION
**What the Taiji?!** supports the pdShared protocol/specification. It contains a count for the number of puzzles solved in its data blob, `solvedPuzzles`.

Moreover, What the Taiji?! supports other games that utilize pdShared for custom puzzles. Games that have a `puzzles` subdirectory in their `Data` directory (i.e., `/Shared/com.gammagames.pomodoro/Data/puzzles`, and those puzzles include valid What the Taiji?! puzzle files (`filename.wtp`), they will appear in the puzzle picker in What the Taiji?!.

![GIF demonstrating the shared data capabilities in What the Taiji?!](https://github.com/user-attachments/assets/f7725816-1f23-4364-a05f-fffebf08ffa2)
